### PR TITLE
Update bignbr.c

### DIFF
--- a/bignbr.c
+++ b/bignbr.c
@@ -101,8 +101,7 @@ bool bignbr_cmp_str (bignbr *a, unsigned char *v)
 	unsigned int i;
 	int j;
 	
-	if (strlen (v) > a->len ||
-	    bignbr_get_eon_pos (a) != strlen (v) ||
+	if (bignbr_get_eon_pos (a) != strlen (v) ||
 	    a->data[BIGNBR_SIGN] != v[BIGNBR_SIGN])
 	{
 		return false;


### PR DESCRIPTION
Removed an unnecessary statement from the *bignbr_cmp_str* function.
The case *strlen (v) > a->len* is covered by the next statement *bignbr_get_eon_pos (a) != strlen (v)*.